### PR TITLE
keep filter state in browser query string

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "camelcase-keys": "5.2.0",
     "date-fns": "^1.30.1",
     "prop-types": "^15.7.2",
+    "query-string": "^6.4.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",

--- a/src/FilterContainer/normalize.js
+++ b/src/FilterContainer/normalize.js
@@ -1,0 +1,27 @@
+import { storyTypes } from '../storyTypes';
+
+const storyTypesArray = storyTypes.map(storyType => storyType.key);
+
+function ensureArray(data) {
+  if (!data) {
+    return [];
+  }
+
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  return [data];
+}
+
+function normalizeOwners(data, uniqueOwnerIds) {
+  return ensureArray(data)
+    .map(id => parseInt(id))
+    .filter(id => uniqueOwnerIds.includes(id));
+}
+
+function normalizeTypes(data) {
+  return ensureArray(data).filter(type => storyTypesArray.includes(type));
+}
+
+export { normalizeOwners, normalizeTypes };

--- a/src/FilterContainer/queryState.js
+++ b/src/FilterContainer/queryState.js
@@ -1,0 +1,33 @@
+import { window } from '../services';
+import { normalizeOwners, normalizeTypes } from './normalize';
+
+const queryString = require('query-string');
+
+const queryStringOptions = {
+  arrayFormat: 'comma'
+};
+
+function getQueryState(uniqueOwnerIds) {
+  const queryState = queryString.parse(
+    window.location.search,
+    queryStringOptions
+  );
+
+  return {
+    selectedOwners: normalizeOwners(queryState.selectedOwners, uniqueOwnerIds),
+    selectedTypes: normalizeTypes(queryState.selectedTypes)
+  };
+}
+
+function setQueryState(state) {
+  window.history.pushState(
+    {},
+    document.title,
+    `${window.location.pathname}?${queryString.stringify(
+      state,
+      queryStringOptions
+    )}`
+  );
+}
+
+export { getQueryState, setQueryState };

--- a/src/FilterContainer/reducer.js
+++ b/src/FilterContainer/reducer.js
@@ -1,6 +1,6 @@
 import { arrayToggle, arrayRotateForward, arrayRotateBackward } from '../utils';
 
-export const reducer = (state, action) => {
+export const reducer = (state, action, uniqueOwnerIds) => {
   const { type, payload } = action;
 
   switch (type) {
@@ -22,7 +22,7 @@ export const reducer = (state, action) => {
       return {
         ...state,
         selectedOwners: [
-          arrayRotateForward(state.uniqueOwnerIds, state.selectedOwners[0])
+          arrayRotateForward(uniqueOwnerIds, state.selectedOwners[0])
         ]
       };
     }
@@ -31,7 +31,7 @@ export const reducer = (state, action) => {
       return {
         ...state,
         selectedOwners: [
-          arrayRotateBackward(state.uniqueOwnerIds, state.selectedOwners[0])
+          arrayRotateBackward(uniqueOwnerIds, state.selectedOwners[0])
         ]
       };
     }

--- a/src/FilterSummary.js
+++ b/src/FilterSummary.js
@@ -1,0 +1,31 @@
+import React, { useContext } from 'react';
+import { Initials } from './Initials';
+import { FilterContext } from './FilterContainer';
+import { storyTypes } from './storyTypes';
+
+function FilterSummary() {
+  const { selectedTypes, selectedOwners } = useContext(FilterContext);
+
+  return (
+    <div className="tags">
+      {selectedOwners.map(id => (
+        <span className="tag is-primary" key={id}>
+          <Initials id={id} />
+        </span>
+      ))}
+
+      {storyTypes
+        .filter(type => selectedTypes.includes(type.key))
+        .map(type => (
+          <span
+            className={`tag is-uppercase ${type.activeClass}`}
+            key={type.key}
+          >
+            {type.key}
+          </span>
+        ))}
+    </div>
+  );
+}
+
+export { FilterSummary };

--- a/src/FilterSummary.test.js
+++ b/src/FilterSummary.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from 'react-testing-library';
+import { PeopleContext } from './PeopleContext';
+import { FilterContainer } from './FilterContainer';
+import { FilterSummary } from './FilterSummary';
+import { window } from './services';
+
+jest.mock('./services/window');
+
+describe('FilterSummary', () => {
+  it('renders according to snapshot', () => {
+    const people = {
+      1: { initials: 'AA' },
+      2: { initials: 'BB' },
+      3: { initials: 'CC' }
+    };
+
+    const uniqueOwnerIds = [1, 2, 3];
+
+    window.location.search = 'selectedOwners=1,2&selectedTypes=bug,feature';
+
+    const { container } = render(
+      <PeopleContext.Provider value={people}>
+        <FilterContainer uniqueOwnerIds={uniqueOwnerIds}>
+          <FilterSummary />
+        </FilterContainer>
+      </PeopleContext.Provider>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/Filters.js
+++ b/src/Filters.js
@@ -7,25 +7,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { Initials } from './Initials';
 import { FilterContext } from './FilterContainer';
-
-const storyTypes = [
-  {
-    key: 'feature',
-    activeClass: 'is-primary'
-  },
-  {
-    key: 'bug',
-    activeClass: 'is-danger'
-  },
-  {
-    key: 'chore',
-    activeClass: 'is-info'
-  },
-  {
-    key: 'blocked',
-    activeClass: 'is-warning'
-  }
-];
+import { storyTypes } from './storyTypes';
 
 const Filters = () => {
   const {

--- a/src/Project.js
+++ b/src/Project.js
@@ -11,6 +11,7 @@ import { Tray } from './Tray';
 import { Filters } from './Filters';
 import { FilterContainer } from './FilterContainer';
 import { PeopleContext } from './PeopleContext';
+import { FilterSummary } from './FilterSummary';
 
 const Project = ({ uniqueOwnerIds, people, stories }) => (
   <PeopleContext.Provider value={people}>
@@ -25,7 +26,7 @@ const Project = ({ uniqueOwnerIds, people, stories }) => (
       </section>
 
       <Footer>
-        <Tray title="Filters">
+        <Tray rightAlign title="Filters" renderLabel={() => <FilterSummary />}>
           <Filters />
         </Tray>
       </Footer>

--- a/src/Project.js
+++ b/src/Project.js
@@ -16,7 +16,7 @@ import { FilterSummary } from './FilterSummary';
 const Project = ({ uniqueOwnerIds, people, stories }) => (
   <PeopleContext.Provider value={people}>
     <FilterContainer uniqueOwnerIds={uniqueOwnerIds}>
-      <section className="section" style={{ paddingBottom: '4rem' }}>
+      <section className="section" style={{ paddingBottom: '12rem' }}>
         <div className="columns">
           <PendingColumn stories={stories} />
           <StartedColumn stories={stories} />

--- a/src/Tray.js
+++ b/src/Tray.js
@@ -11,7 +11,7 @@ const trayStyle = {
   boxShadow: '0 -2px 3px rgba(10,10,10,.1), 0 0 0 1px rgba(10,10,10,.1)'
 };
 
-const Tray = ({ title, children, rightAlign }) => {
+const Tray = ({ title, children, renderLabel }) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -27,20 +27,24 @@ const Tray = ({ title, children, rightAlign }) => {
       </div>
 
       <a
-        style={{
-          justifyContent: rightAlign ? 'flex-end' : 'flex-start'
-        }}
+        style={{ justifyContent: 'flex-start' }}
         className="button is-fullwidth is-dark is-medium is-radiusless"
         onClick={() => setOpen(!open)}
       >
         <span>{title}</span>
 
-        <span className="icon is-small">
+        <span className="icon is-small" style={{ margin: '0' }}>
           <FontAwesomeIcon icon={open ? faAngleDown : faAngleUp} />
         </span>
+
+        {!open && <div style={{ marginLeft: '.5rem' }}>{renderLabel()}</div>}
       </a>
     </div>
   );
+};
+
+Tray.defaultProps = {
+  renderLabel: () => {}
 };
 
 export { Tray };

--- a/src/Tray.test.js
+++ b/src/Tray.test.js
@@ -35,6 +35,17 @@ describe('Tray', () => {
 
       expect(getByTestId('tray')).toHaveStyle('transform: translateY(0)');
     });
+
+    it('renders label', () => {
+      const { queryByText } = render(
+        <Tray title="title" renderLabel={() => <div>Closed label</div>}>
+          <TestChild />
+        </Tray>
+      );
+
+      expect(queryByText('Closed label')).toBeInTheDocument();
+    });
+
     it('renders angle-up icon', () => {
       const { container } = render(
         <Tray title="title">
@@ -70,6 +81,19 @@ describe('Tray', () => {
 
       expect(container.querySelector('svg')).toHaveClass('fa-angle-down');
     });
+
+    it('does not render label', () => {
+      const { container, queryByText } = render(
+        <Tray title="title" renderLabel={() => <div>Closed label</div>}>
+          <TestChild />
+        </Tray>
+      );
+
+      fireEvent.click(container.querySelector('a'));
+
+      expect(queryByText('Closed label')).not.toBeInTheDocument();
+    });
+
     it('closes on click', () => {
       const { container, getByTestId } = render(
         <Tray title="title">

--- a/src/__snapshots__/FilterSummary.test.js.snap
+++ b/src/__snapshots__/FilterSummary.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FilterSummary renders according to snapshot 1`] = `
+<div
+  class="tags"
+>
+  <span
+    class="tag is-primary"
+  >
+    <span
+      class="is-uppercase"
+    >
+      AA
+    </span>
+  </span>
+  <span
+    class="tag is-primary"
+  >
+    <span
+      class="is-uppercase"
+    >
+      BB
+    </span>
+  </span>
+  <span
+    class="tag is-uppercase is-primary"
+  >
+    feature
+  </span>
+  <span
+    class="tag is-uppercase is-danger"
+  >
+    bug
+  </span>
+</div>
+`;

--- a/src/services/__mocks__/window.js
+++ b/src/services/__mocks__/window.js
@@ -1,0 +1,28 @@
+let locationSearch = '';
+
+const mockWindow = {
+  cleanup: () => {
+    locationSearch = '';
+  },
+
+  location: {
+    get search() {
+      return locationSearch;
+    },
+
+    set search(value) {
+      locationSearch = value;
+    }
+  },
+
+  history: {
+    pushState: (_state, _title, url) => {
+      locationSearch = url.split('?')[1];
+    }
+  },
+
+  addEventListener: () => {},
+  removeEventListener: () => {}
+};
+
+export default mockWindow;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,1 @@
+export { default as window } from './window';

--- a/src/services/window.js
+++ b/src/services/window.js
@@ -1,0 +1,1 @@
+export default window;

--- a/src/storyTypes.js
+++ b/src/storyTypes.js
@@ -1,0 +1,18 @@
+export const storyTypes = [
+  {
+    key: 'feature',
+    activeClass: 'is-primary'
+  },
+  {
+    key: 'bug',
+    activeClass: 'is-danger'
+  },
+  {
+    key: 'chore',
+    activeClass: 'is-info'
+  },
+  {
+    key: 'blocked',
+    activeClass: 'is-warning'
+  }
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8625,6 +8625,15 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.4.2.tgz#8be1dbd105306aebf86022144f575a29d516b713"
+  integrity sha512-DfJqAen17LfLA3rQ+H5S4uXphrF+ANU1lT2ijds4V/Tj4gZxA3gx5/tg1bz7kYCmwna7LyJNCYqO7jNRzo3aLw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -9732,6 +9741,11 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -9830,6 +9844,11 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
by having a local state with the keys. on state changes the browser query string is and hisory is updated using pushState.
When the user navigates back and forth in the hisory the popstate event is fired and the new browser query string is written to the local state.

Had the popstate event been fired when the browser history is changed using the pushState function, it would not be neseccary to have the local state at all. Unfortunately that is not the case.

closes #33, #7 