### PR TITLE
dont open dragged item as page in firefox

### DIFF
--- a/src/ColumnContainer.js
+++ b/src/ColumnContainer.js
@@ -12,7 +12,8 @@ function ColumnContainer({ children, dispatch }) {
     });
   };
 
-  const handleDrop = () => {
+  const handleDrop = e => {
+    e.preventDefault();
     const { origin, target, storyId } = state;
 
     if (origin !== target) {


### PR DESCRIPTION
by preventing browser default action on drop