### PR TITLE
bugfix/unknown blockers

### DIFF
--- a/src/ProjectContainer.js
+++ b/src/ProjectContainer.js
@@ -40,7 +40,14 @@ function reducer(state, action) {
 
       payload.forEach(story => {
         if (story.blockers.length > 0) {
-          storiesWithBlockers[story.id].blockers = story.blockers;
+          if (storiesWithBlockers[story.id]) {
+            storiesWithBlockers[story.id].blockers = story.blockers;
+          } else {
+            console.warn(
+              'Recieved blockers for unknow story, with id',
+              story.id
+            );
+          }
         }
       });
 

--- a/src/ProjectContainer.js
+++ b/src/ProjectContainer.js
@@ -136,10 +136,6 @@ function ProjectContainer({ id, render }) {
           type: 'FETCH_ITERATION_SUCCESS',
           payload: { iterationResponse, membershipsResponse, epicsResponse }
         });
-
-        const blockers = await getBlockers(id, getStoryIds(iterationResponse));
-
-        dispatch({ type: 'FETCH_BLOCKERS_SUCCESS', payload: blockers });
       } catch (error) {
         dispatch({ type: 'FETCH_REQUEST_ERROR', payload: error });
       }
@@ -147,6 +143,22 @@ function ProjectContainer({ id, render }) {
 
     fetchData(id);
   }, [id]);
+
+  useEffect(() => {
+    const fetchBlockers = async () => {
+      try {
+        const blockers = await getBlockers(id, state.storyIds);
+
+        dispatch({ type: 'FETCH_BLOCKERS_SUCCESS', payload: blockers });
+      } catch (error) {
+        dispatch({ type: 'FETCH_REQUEST_ERROR', payload: error });
+      }
+    };
+
+    if (state.storyIds.length > 0) {
+      fetchBlockers();
+    }
+  }, [id, state.storyIds]);
 
   useEffect(() => {
     const updateStorySideEffect = async ({ storyId, target }) => {

--- a/src/ProjectContainer.js
+++ b/src/ProjectContainer.js
@@ -8,7 +8,7 @@ import {
   getEpics
 } from './api';
 import { Spinner } from './Spinner';
-import { normalize, getStoryIds } from './normalize';
+import { normalize } from './normalize';
 import { Project } from './Project';
 
 const initialState = {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -25,7 +25,7 @@ const uniqueArray = array =>
 
 const removeReleaseStories = story => story.storyType !== 'release';
 
-const normalize = ({
+export const normalize = ({
   iterationResponse,
   membershipsResponse,
   epicsResponse
@@ -63,9 +63,11 @@ const normalize = ({
     (acc, story) => acc.concat(story.labels.map(label => label.id)),
     []
   );
+
   const activeEpics = epicsResponse.filter(epic =>
     activeLabelIds.includes(epic.label.id)
   );
+
   activeEpics.push({
     id: -1,
     kind: 'epic',
@@ -89,8 +91,3 @@ const normalize = ({
     uniqueEpicIds
   };
 };
-
-const getStoryIds = iterationResponse =>
-  iterationResponse[0].stories.map(story => story.id);
-
-export { normalize, getStoryIds };


### PR DESCRIPTION
https://github.com/jobn/braid/issues/78

The issue in the bug was that the particular project had blockers on a release story.
Since the normalisation removes the release stories they are not in the state.
However, the request for the blocker were built using the un-normalised storyIds (which contains the release stories), causing the payload of that request to also hold blockers for these stories. Adding them to state failed because the stories were not there.

The fix in this pr is to build the blocker request using the normalised state, that does not hold the release-story-ids